### PR TITLE
fix create_issue syntax

### DIFF
--- a/lib/errbit_github_plugin/issue_tracker.rb
+++ b/lib/errbit_github_plugin/issue_tracker.rb
@@ -63,7 +63,7 @@ module ErrbitGithubPlugin
       options[:github_repo]
     end
 
-    def create_issue(title, body, user: {})
+    def create_issue(title, body, user={})
       if user['github_login'] && user['github_oauth_token']
         github_client = Octokit::Client.new(
           login: user['github_login'], access_token: user['github_oauth_token'])


### PR DESCRIPTION
As a user of the Chef errbit cookbook/recipes, I noticed a run started to fail (it brings this in on run).
I traced it back to this.

Prior to fix-

```
1.9.3-p547 :001 > require 'errbit_github_plugin'
SyntaxError: .rvm/gems/ruby-1.9.3-p547/gems/errbit_github_plugin-0.1.0/lib/errbit_github_plugin/issue_tracker.rb:66: syntax error, unexpected tASSOC, expecting ')'
    def create_issue(title, body, user: {})
                                       ^
.rvm/gems/ruby-1.9.3-p547/gems/errbit_github_plugin-0.1.0/lib/errbit_github_plugin/issue_tracker.rb:80: syntax error, unexpected keyword_end, expecting $end
    from .rvm/rubies/ruby-1.9.3-p547/lib/ruby/site_ruby/1.9.1/rubygems/core_ext/kernel_require.rb:55:in `require'
    from .rvm/rubies/ruby-1.9.3-p547/lib/ruby/site_ruby/1.9.1/rubygems/core_ext/kernel_require.rb:55:in `require'
    from .rvm/gems/ruby-1.9.3-p547/gems/errbit_github_plugin-0.1.0/lib/errbit_github_plugin.rb:3:in `<top (required)>'
    from .rvm/rubies/ruby-1.9.3-p547/lib/ruby/site_ruby/1.9.1/rubygems/core_ext/kernel_require.rb:135:in `require'
    from .rvm/rubies/ruby-1.9.3-p547/lib/ruby/site_ruby/1.9.1/rubygems/core_ext/kernel_require.rb:135:in `rescue in require'
    from .rvm/rubies/ruby-1.9.3-p547/lib/ruby/site_ruby/1.9.1/rubygems/core_ext/kernel_require.rb:144:in `require'
    from (irb):1
    from .rvm/rubies/ruby-1.9.3-p547/bin/irb:12:in `<main>'
```

With fix-

```
1.9.3-p547 :003 > require 'errbit_github_plugin'
 => true 
```
