### PR TITLE
Fix homepage to reflect the new github repo.

### DIFF
--- a/errbit_github_plugin.gemspec
+++ b/errbit_github_plugin.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
 
   spec.description   = %q{GitHub integration for Errbit}
   spec.summary       = %q{GitHub integration for Errbit}
-  spec.homepage      = "https://github.com/brandedcrate/errbit_github_plugin"
+  spec.homepage      = "https://github.com/errbit/errbit_github_plugin"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files`.split($/)


### PR DESCRIPTION
This repo seems to have the latest errbit_github_plugin code, but the homepage in rubygems links to brandedcrate/errbit_github_plugin.

I'm guessing the code was moved from brandedcrate/errbit_github_plugin to this repo, so I updated the homepage in the gemspec accordingly.